### PR TITLE
Service keypair

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,10 +21,10 @@ require (
 	go.dedis.ch/onet/v3 v3.0.4
 	go.dedis.ch/protobuf v1.0.6
 	go.etcd.io/bbolt v1.3.2 // indirect
-	golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576
+	golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c
 	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20190324223953-e3b2ff56ed87 // indirect
-	golang.org/x/tools v0.0.0-20190322203728-c1a832b0ad89 // indirect
+	golang.org/x/tools v0.0.0-20190325223049-1d95b17f1b04 // indirect
 	gonum.org/v1/gonum v0.0.0-20190321072728-ca4d35bc590a
 	gopkg.in/satori/go.uuid.v1 v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a h1:YX8ljsm6wXlHZO+aRz9Exq
 golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576 h1:aUX/1G2gFSs4AsJJg2cL3HuoRhCSCz733FE5GUSuaT4=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0FNOmBrHfq7vN4btdGoDZgI=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -339,6 +341,8 @@ golang.org/x/tools v0.0.0-20190321232350-e250d351ecad h1:tYrC3aF7wTeS1noni7wCGu9
 golang.org/x/tools v0.0.0-20190321232350-e250d351ecad/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190322203728-c1a832b0ad89 h1:iWXXYN3edZ3Nd/7I6Rt1sXrWVmhF9bgVtlEJ7BbH124=
 golang.org/x/tools v0.0.0-20190322203728-c1a832b0ad89/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190325223049-1d95b17f1b04 h1:SRYGE+BqJRgY8JH4p2NmwTPeuREKqKYw5IuEmthTHKQ=
+golang.org/x/tools v0.0.0-20190325223049-1d95b17f1b04/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gonum.org/v1/gonum v0.0.0-20190312022028-60a68a3a7f2c h1:vkUG1VH//F1/AT8sZfBgWZdtBeUa8/Vh/lQx/P0JIcQ=
 gonum.org/v1/gonum v0.0.0-20190312022028-60a68a3a7f2c/go.mod h1:jevfED4GnIEnJrWW55YmY9DMhajHcnkqVnEXmEtMyNI=
 gonum.org/v1/gonum v0.0.0-20190321072728-ca4d35bc590a h1:XffIu/i+IJIC+M8WoBEmJm8N/YYbA8Pvh748YgzU7kI=

--- a/lib/shuffling_proof.go
+++ b/lib/shuffling_proof.go
@@ -135,7 +135,7 @@ func checkShuffleProof(g, h kyber.Point, Xhat, Yhat, XhatBar, YhatBar []kyber.Po
 	err := proof.HashVerify(libunlynx.SuiTe, "PairShuffle", verifier, prf)
 	if err != nil {
 		log.Lvl1(err)
-		log.Lvl1("-----------verify failed (with XharBar)")
+		log.Lvl1("-----------verify failed (with XhatBar)")
 		return false
 	}
 

--- a/lib/structs_proofs.go
+++ b/lib/structs_proofs.go
@@ -129,12 +129,18 @@ func (rpr *RangeProofRequest) VerifyProof(source network.ServerIdentity, sq Surv
 	wg := libunlynx.StartParallelize(1)
 	go func() {
 		defer wg.Done()
+		var err error
 		err = VerifyProofSignature(sq.IDtoPublic[rpr.SenderID], rpr.Data, rpr.Signature)
 		if err != nil {
 			verifSign = proofFalseSign
 		}
 	}()
-	verif := verifyRangeProofList(rpr.Data, sq.Threshold, sq.Query.Ranges, sq.Query.IVSigs.InputValidationSigs, sq.RosterServers.Aggregate, sq.RangeProofThreshold)
+	agg, err := sq.RosterServers.ServiceAggregate("drynx")
+	if err != nil {
+		// It's in protocol-test mode only, so the aggregate point of all conodes will do
+		agg = sq.RosterServers.Aggregate
+	}
+	verif := verifyRangeProofList(rpr.Data, sq.Threshold, sq.Query.Ranges, sq.Query.IVSigs.InputValidationSigs, agg, sq.RangeProofThreshold)
 	log.Lvl2("VN", source.String(), " verified range proof:", verif)
 	libunlynx.EndParallelize(wg)
 	//libunlynx.EndTimer(time)
@@ -387,7 +393,12 @@ func verifyShuffle(data []byte, sample float64, roster onet.Roster) int64 {
 
 		toVerify := &PublishedShufflingProof{}
 		toVerify.FromBytes(*proofs.(*PublishedShufflingProofBytes))
-		result := ShufflingProofVerification(*toVerify, roster.Aggregate)
+		agg, err := roster.ServiceAggregate("drynx")
+		if err != nil {
+			// It's in protocol-test mode only, so the aggregate point of all conodes will do
+			agg = roster.Aggregate
+		}
+		result := ShufflingProofVerification(*toVerify, agg)
 
 		if result {
 			bmInt = ProofTrue

--- a/lib/suite.go
+++ b/lib/suite.go
@@ -2,11 +2,9 @@ package libdrynx
 
 import (
 	"github.com/lca1/unlynx/lib"
-	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/kyber/v3/pairing/bn256"
 )
 
 func init() {
-	cothority.Suite = bn256.NewSuiteG1()
 	libunlynx.SuiTe = bn256.NewSuiteG1()
 }

--- a/protocols/shuffling_protocol.go
+++ b/protocols/shuffling_protocol.go
@@ -142,7 +142,7 @@ func (p *ShufflingProtocol) Start() error {
 		shuffleTarget = append(shuffleTarget, pr)
 	}
 
-	collectiveKey := p.Roster().Aggregate
+	collectiveKey := p.Aggregate()
 	if p.CollectiveKey != nil {
 		//test
 		collectiveKey = p.CollectiveKey
@@ -209,7 +209,7 @@ func (p *ShufflingProtocol) Dispatch() error {
 	startT := time.Now()
 	roundTotalComputation := libunlynx.StartTimer(p.Name() + "_Shuffling(DISPATCH)")
 
-	collectiveKey := p.Roster().Aggregate //shuffling is by default done with collective authority key
+	collectiveKey := p.Aggregate() //shuffling is by default done with collective authority key
 
 	if p.CollectiveKey != nil {
 		//test

--- a/protocols/shufflinglocal_protocol.go
+++ b/protocols/shufflinglocal_protocol.go
@@ -113,7 +113,7 @@ func (p *ShufflingLocalProtocol) Dispatch() error {
 	startT := time.Now()
 	roundTotalComputation := libunlynx.StartTimer(p.Name() + "_Shuffling(DISPATCH)")
 
-	collectiveKey := p.Roster().Aggregate //shuffling is by default done with collective authority key
+	collectiveKey := p.Aggregate() //shuffling is by default done with collective authority key
 
 	if p.CollectiveKey != nil {
 		//test

--- a/services/api.go
+++ b/services/api.go
@@ -4,6 +4,7 @@ import (
 	"github.com/lca1/drynx/lib"
 	"github.com/lca1/drynx/lib/encoding"
 	"github.com/lca1/unlynx/lib"
+	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/onet/v3"
@@ -34,7 +35,7 @@ func init() {
 func NewDrynxClient(entryPoint *network.ServerIdentity, clientID string) *API {
 	keys := key.NewKeyPair(libunlynx.SuiTe)
 	newClient := &API{
-		Client:     onet.NewClient(libunlynx.SuiTe, ServiceName),
+		Client:     onet.NewClient(cothority.Suite, ServiceName),
 		clientID:   clientID,
 		entryPoint: entryPoint,
 		public:     keys.Public,

--- a/services/service_test.go
+++ b/services/service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"go.dedis.ch/cothority/v3"
 
 	"github.com/lca1/drynx/lib/encoding"
 	"github.com/lca1/unlynx/lib"
@@ -100,7 +101,7 @@ func TestServiceDrynx(t *testing.T) {
 		thresholdEntityProofsVerif = []float64{0.0, 0.0, 0.0, 0.0}
 	}
 
-	local := onet.NewLocalTest(libunlynx.SuiTe)
+	local := onet.NewLocalTest(cothority.Suite)
 	elServers, elDPs, elVNs := generateNodes(local, nbrServers, nbrDPs, nbrVNs)
 
 	if proofs == 0 {
@@ -222,15 +223,15 @@ func TestServiceDrynx(t *testing.T) {
 
 		idToPublic := make(map[string]kyber.Point)
 		for _, v := range elServers.List {
-			idToPublic[v.String()] = v.Public
+			idToPublic[v.String()] = v.ServicePublic(ServiceName)
 		}
 		for _, v := range elDPs.List {
-			idToPublic[v.String()] = v.Public
+			idToPublic[v.String()] = v.ServicePublic(ServiceName)
 		}
 
 		if proofs != 0 {
 			for _, v := range elVNs.List {
-				idToPublic[v.String()] = v.Public
+				idToPublic[v.String()] = v.ServicePublic(ServiceName)
 			}
 		}
 
@@ -428,7 +429,7 @@ func TestServiceDrynxLogisticRegressionForSPECTF(t *testing.T) {
 		thresholdEntityProofsVerif = []float64{0.0, 0.0, 0.0, 0.0}
 	}
 
-	local := onet.NewLocalTest(libunlynx.SuiTe)
+	local := onet.NewLocalTest(cothority.Suite)
 	elServers, elDPs, elVNs := generateNodes(local, nbrServers, nbrDPs, nbrVNs)
 
 	if proofs == 0 {
@@ -550,15 +551,15 @@ func TestServiceDrynxLogisticRegressionForSPECTF(t *testing.T) {
 
 		idToPublic := make(map[string]kyber.Point)
 		for _, v := range elServers.List {
-			idToPublic[v.String()] = v.Public
+			idToPublic[v.String()] = v.ServicePublic(ServiceName)
 		}
 		for _, v := range elDPs.List {
-			idToPublic[v.String()] = v.Public
+			idToPublic[v.String()] = v.ServicePublic(ServiceName)
 		}
 
 		if proofs != 0 {
 			for _, v := range elVNs.List {
-				idToPublic[v.String()] = v.Public
+				idToPublic[v.String()] = v.ServicePublic(ServiceName)
 			}
 		}
 
@@ -708,9 +709,9 @@ func TestServiceDrynxLogisticRegression(t *testing.T) {
 	os.Remove("pre_compute_multiplications.gob")
 
 	// these nodes act as both servers and data providers
-	local := onet.NewLocalTest(libunlynx.SuiTe)
-	local1 := onet.NewLocalTest(libunlynx.SuiTe)
-	local2 := onet.NewLocalTest(libunlynx.SuiTe)
+	local := onet.NewLocalTest(cothority.Suite)
+	local1 := onet.NewLocalTest(cothority.Suite)
+	local2 := onet.NewLocalTest(cothority.Suite)
 
 	// create servers and data providers
 	_, el, _ := local.GenTree(10, true)
@@ -907,13 +908,13 @@ func TestServiceDrynxLogisticRegression(t *testing.T) {
 
 		idToPublic := make(map[string]kyber.Point)
 		for _, v := range el.List {
-			idToPublic[v.String()] = v.Public
+			idToPublic[v.String()] = v.ServicePublic(ServiceName)
 		}
 		for _, v := range el1.List {
-			idToPublic[v.String()] = v.Public
+			idToPublic[v.String()] = v.ServicePublic(ServiceName)
 		}
 		for _, v := range elVNs.List {
-			idToPublic[v.String()] = v.Public
+			idToPublic[v.String()] = v.ServicePublic(ServiceName)
 		}
 
 		thresholdEntityProofsVerif := []float64{1.0, 1.0, 1.0, 1.0} // 1: threshold general, 2: threshold range, 3: obfuscation, 4: threshold key switch

--- a/simul/drynx_simul.go
+++ b/simul/drynx_simul.go
@@ -329,13 +329,13 @@ func (sim *SimulationDrynx) Run(config *onet.SimulationConfig) error {
 
 	idToPublic := make(map[string]kyber.Point)
 	for _, v := range rosterServers.List {
-		idToPublic[v.String()] = v.Public
+		idToPublic[v.String()] = v.ServicePublic(services.ServiceName)
 	}
 	for _, v := range rosterVNs.List {
-		idToPublic[v.String()] = v.Public
+		idToPublic[v.String()] = v.ServicePublic(services.ServiceName)
 	}
 	for _, v := range elDPs {
-		idToPublic[v.String()] = v.Public
+		idToPublic[v.String()] = v.ServicePublic(services.ServiceName)
 	}
 
 	// Create a client (querier) for the service)

--- a/simul/runfiles/drynx.toml
+++ b/simul/runfiles/drynx.toml
@@ -1,7 +1,7 @@
 Simulation = "ServiceDrynx"
 Servers = 6
 Bf = 2
-Suite = "bn256.G1"
+Suite = "Ed25519"
 Rounds = 1
 Bandwidth = 100
 Delay = 20


### PR DESCRIPTION
Instead of using the conode's keypair, this PR enables the `cothority.v3` usage of service keypairs. This allows for multiple services to be used with different cryptographic groups.